### PR TITLE
fix: Add Unsplash as a remote pattern for images

### DIFF
--- a/sents-web/next.config.mjs
+++ b/sents-web/next.config.mjs
@@ -4,6 +4,7 @@ const nextConfig = {
     remotePatterns: [
       { protocol: 'https', hostname: 'source.unsplash.com' },
       { protocol: 'https', hostname: 'flagsapi.com' },
+      { protocol: 'https', hostname: 'unsplash.com' },
     ],
   },
 };


### PR DESCRIPTION
## Description
- Fix for broken image urls

## Issue(s) Addressed
List the issues affected by this change.

## Testing
Describe the testing you have performed to ensure this change is correct.

## Checklist
- [x] I have added necessary documentation (if appropriate)
- [x] I've tested this locally
- [x] This change ready to hit production in its current state

## Screenshots (optional)
![image](https://github.com/user-attachments/assets/6866a18c-a56c-43cf-ba98-1c7d81cee21d)
